### PR TITLE
Avoid crash for GCC 6

### DIFF
--- a/AMEGIC++/Main/Point.C
+++ b/AMEGIC++/Main/Point.C
@@ -219,8 +219,6 @@ std::ostream & operator<<(std::ostream & s, const Point & p)
 
 void Point::FindOrder(std::vector<int> &order)
 {
-  if (!this) return;
-
   // HS added this to prevent run-time segfault when compiled with gcc6
   if (v == NULL) return;
 
@@ -230,7 +228,9 @@ void Point::FindOrder(std::vector<int> &order)
     for (size_t i(0);i<v->order.size();++i)
       order[i]+=v->order[i];
   }
-  left->FindOrder(order);
-  right->FindOrder(order);
-  if (middle) middle->FindOrder(order);
+  if (left) {
+    left->FindOrder(order);
+    right->FindOrder(order);
+    if (middle) middle->FindOrder(order);
+  }
 }


### PR DESCRIPTION
data member Point::left can be zero, so check it before calling Point::FindOrder